### PR TITLE
Remove git submodule containing libuv

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "deps/libuv"]
-	path = deps/libuv
-	url = https://github.com/libuv/libuv
-	branch = v1.x


### PR DESCRIPTION
I've decided to remove git submodules, this could result a bit
confusing and hard to getting started people (includgin myself).