### PR TITLE
Remove npm stuff

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,17 +3,8 @@
   "version": "1.0.0",
   "description": "This project is just for show some examples of [libuv](http://libuv.org/) API. _Read [basics of libuv](http://docs.libuv.org/en/v1.x/guide/basics.html#basics-of-libuv) first_.",
   "main": "menu/menu.js",
-  "dependencies": {
-    "extended-terminal-menu": "^2.1.4"
-  },
-  "devDependencies": {
-    "standard": "^14.3.1"
-  },
-  "scripts": {
-    "start": "node menu/menu.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "standard"
-  },
+  "dependencies": {},
+  "scripts": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/juanarbol/uvxamples.git"


### PR DESCRIPTION
I'm removing node stuff for handling the way the examples runs,
but leaving package.json file for distribute this tru npm.